### PR TITLE
Fix the bug that `df_name` was not provided on `create_database`

### DIFF
--- a/api/databases.py
+++ b/api/databases.py
@@ -194,15 +194,17 @@ def _create_database(info: dict):
     except ObjectDoesNotExist:
         pass
 
-    # Prepare DBHandler
+    # Prepare database
     handler = DBHandler(
-        db_class='database_id',
+        db_class='meta',
+        database_id=info['database_id'],
         read_on_init=False
     )
-    handler.add_data(info)
     handler.save()
 
-    resp = info
+    # Update database
+    resp = _update_database(info['database_id'], info)
+
     return resp
 
 


### PR DESCRIPTION
## What?
`create_database` 関数で追加される情報に `df_name` が含まれていないバグを修正

## Why?
バグ修正のため