### PR TITLE
Support for managing configs

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# Copyright API authors
+"""Record related functions."""
+
+from fastapi import APIRouter, HTTPException, Body
+
+from api.exceptions import ObjectDoesNotExist, InvalidObject, InvalidData
+from api.databases import _get_database
+from api.utils import filter_data, validate_input_data, get_db_handler
+
+from pydtk.utils.utils import DTYPE_MAP
+
+router = APIRouter(
+    tags=["config"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.get('/databases/{database_id}/config')
+def get_config(database_id: str):
+    """Get config.
+
+    Args:
+        database_id (str): database-id
+
+    Returns:
+        (json): config
+
+    """
+    try:
+        resp = _get_config(database_id)
+        resp = filter_data(resp)
+        return resp
+    except AssertionError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except ObjectDoesNotExist as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except InvalidObject as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch('/databases/{database_id}/config')
+def update_config(database_id: str, data=Body(...)):
+    """Patch config.
+
+    Args:
+        database_id (str): database-id
+        data (Body): new config
+
+    Returns:
+        (json): config
+
+    """
+    try:
+        validate_input_data(data)
+        resp = _update_config(database_id, data)
+        resp = filter_data(resp)
+        return resp
+    except ObjectDoesNotExist:
+        raise HTTPException(status_code=404, detail='No config found')
+    except InvalidObject as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    except InvalidData as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except AssertionError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+def _get_config(database_id: str):
+    """Get config.
+
+    Args:
+        database_id (str): ID of the database
+
+    Returns:
+        (dict): config
+
+    """
+    # Check the existence of the database-id
+    _ = _get_database(database_id)
+
+    # Prepare handler
+    handler = get_db_handler('config', database_id=database_id)
+    resp = handler.config
+    return resp
+
+
+def _update_config(database_id: str, config):
+    """Update config.
+
+    Args:
+        database_id (str): ID of the database
+        config (dict): record info
+
+    Returns:
+        (dict): config
+
+    """
+    # Check the existence of the database-id
+    _ = _get_database(database_id)
+
+    # Prepare DBHandler
+    handler = get_db_handler('config', database_id=database_id)
+
+    # Validate config
+    if 'columns' in config.keys():
+        # Make sure that column names are the same
+        column_names_original = set([c['name'] for c in handler.config['columns']])
+        column_names_new = set([c['name'] for c in config['columns']])
+        assert column_names_new == column_names_original, \
+            'You can neither add/remove columns nor change the names'
+
+        # Check contents in each columns
+        for column in config['columns']:
+            assert 'name' in column.keys()
+            assert 'dtype' in column.keys()
+            assert 'aggregation' in column.keys()
+            # assert column['dtype'] in DTYPE_MAP.keys()    # This is too strict
+            # TODO: Check the value of column['aggregation']
+
+    if 'index_columns' in config.keys():
+        assert len(config['index_columns']) > 0, \
+            'At least one column must be selected as index_column'
+
+    # Update config
+    handler.config.update(config)
+
+    # Save
+    handler.save()
+
+    # Return
+    resp = handler.config
+
+    return resp

--- a/api/server.py
+++ b/api/server.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, Header
 from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 
-from api import databases, records, files
+from api import databases, records, files, config
 
 
 # Metadata
@@ -48,6 +48,7 @@ api.add_middleware(
 api.include_router(databases.router)
 api.include_router(records.router)
 api.include_router(files.router)
+api.include_router(config.router)
 
 
 @api.get('/')

--- a/api/utils.py
+++ b/api/utils.py
@@ -162,7 +162,7 @@ def get_db_handler(handler_type: str, database_id: str = None) -> DBHandler:
     """Returns DB-Handler.
 
     Args:
-        handler_type (str): 'database', 'record', or 'file'
+        handler_type (str): 'database', 'record', 'file' or 'config'
         database_id (str): database-id (optional)
 
     Returns:
@@ -182,6 +182,13 @@ def get_db_handler(handler_type: str, database_id: str = None) -> DBHandler:
             read_on_init=False
         )
     elif handler_type == 'file':
+        handler = DBHandler(
+            db_class='meta',
+            database_id=database_id,
+            orient='path',
+            read_on_init=False
+        )
+    elif handler_type == 'config':
         handler = DBHandler(
             db_class='meta',
             database_id=database_id,

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# Copyright API authors
+"""Test code."""
+
+import json
+
+import pytest
+from .common import _init_database, _set_env, _set_dummy_env, client
+from .test_databases import add_database
+
+
+@pytest.fixture
+def init():
+    _init_database()
+    _set_env()
+    add_database('default')
+
+
+@pytest.fixture
+def add_data():
+    _set_env()
+    client.post(
+        '/databases/default/records',
+        json={
+            'record_id': 'pytest',
+            'name': 'pytest',
+            'description': 'Description',
+            'list': ['a', 'b', 'c'],
+            'tags': ['tag1', 'tag2']
+        }
+    )
+
+
+def _get_config():
+    _set_env()
+    r = client.get(
+        '/databases/default/config',
+    )
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    return data
+
+
+def test_get_config_200(init, add_data):
+    _set_env()
+    r = client.get(
+        '/databases/default/config',
+    )
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert 'columns' in data.keys()
+    for column in data['columns']:
+        assert 'name' in column.keys()
+        assert 'dtype' in column.keys()
+        assert 'aggregation' in column.keys()
+        assert 'display_name' in column.keys()
+
+
+def test_get_config_404(init, add_data):
+    _set_dummy_env()
+    r = client.get(
+        '/databases/default/config',
+    )
+    assert r.status_code == 404
+
+
+def test_update_config_200(init, add_data):
+    config = _get_config()
+    _set_env()
+    r = client.patch(
+        '/databases/default/config',
+        json=config
+    )
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert str(config) == str(data)
+
+
+def test_update_config_200_2(init, add_data):
+    config = _get_config()
+    for column in config['columns']:
+        column['display_name'] = 'display_name'
+
+    _set_env()
+    r = client.patch(
+        '/databases/default/config',
+        json=config
+    )
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert str(config) == str(data)
+
+
+def test_update_config_400(init, add_data):
+    _set_env()
+    r = client.patch(
+        '/databases/default/config',
+        json={
+            'columns': []
+        }
+    )
+    assert r.status_code == 400
+
+
+def test_update_config_400_2(init, add_data):
+    config = _get_config()
+    for column in config['columns']:
+        column['name'] = ''
+
+    _set_env()
+    r = client.patch(
+        '/databases/default/config',
+        json=config
+    )
+    assert r.status_code == 400
+
+
+def test_update_config_404(init, add_data):
+    _set_dummy_env()
+    r = client.patch(
+        '/databases/default/config',
+        json={}
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
## What?
database 固有の設定（表示カラムの情報等）を管理するためのパス `/databases/{database_id}/config` を追加

## Why?
フロント側から表示方法を変更できるようにするため

## See also [Optional]
https://github.com/dataware-tools/api-meta-store/issues/11
https://github.com/dataware-tools/protocols/pull/32
