### PR TITLE
Add option `search_key`

### DIFF
--- a/test/test_databases.py
+++ b/test/test_databases.py
@@ -44,6 +44,49 @@ def test_list_databases_200(init, add_data):
     assert len(data['data']) > 0
 
 
+def test_fuzzy_search_databases_200(init, add_data):
+    _set_env()
+    r = client.get('/databases', params={
+        'search': 'def'
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) > 0
+
+
+def test_fuzzy_search_databases_200_2(init, add_data):
+    _set_env()
+    r = client.get('/databases', params={
+        'search': 'def',
+        'search_key': ['abc']
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) == 0
+
+
+def test_fuzzy_search_databases_200_3(init, add_data):
+    _set_env()
+    r = client.get('/databases', params={
+        'search': 'def',
+        'search_key': ['abc', 'database_id']
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) > 0
+
+
+def test_fuzzy_search_databases_200_4(init, add_data):
+    _set_env()
+    r = client.get('/databases', params={
+        'search': 'Desc',
+        'search_key': ['description']
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) > 0
+
+
 def test_create_database(init):
     _set_env()
     r = client.get('/databases/default')

--- a/test/test_files.py
+++ b/test/test_files.py
@@ -117,6 +117,20 @@ def test_list_files_404(init):
     assert r.status_code == 404
 
 
+def test_fuzzy_search_files_200(init, add_data):
+    _set_env()
+    r = client.get(
+        '/databases/default/files',
+        params={
+            'search': 'pytest',
+            'search_key': ['name']
+        }
+    )
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) > 0
+
+
 def test_create_file_200(init):
     _set_env()
     r = client.post(

--- a/test/test_records.py
+++ b/test/test_records.py
@@ -109,6 +109,20 @@ def test_search_records_200_4(init, add_data):
     assert len(data['data']) == 0
 
 
+def test_fuzzy_search_records_200(init, add_data):
+    _set_env()
+    r = client.get(
+        '/databases/default/records',
+        params={
+            'search': 'Desc',
+            'search_key': ['record_id', 'description']
+        }
+    )
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) > 0
+
+
 def test_create_record_200(init):
     _set_env()
     r = client.post(


### PR DESCRIPTION
## What?
Solves #20 
あいまい検索の対象キーを指定するためのクエリパラメータ `search_key` を追加

## Why?
キーを指定したいから

## See also [Optional]
https://github.com/dataware-tools/api-meta-store/pull/22
https://github.com/dataware-tools/protocols/pull/41

## Note
https://github.com/dataware-tools/protocols/pull/41 のマージ後にマージする