### PR TITLE
Fix the bug that `is_permitted` was not working properly

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -323,7 +323,7 @@ class CheckPermissionClient:
 
         """
         try:
-            res = requests.post(
+            res = requests.get(
                 f'{self.PERMISSION_MANAGER_SERVICE}/permitted-actions/{action_id}',
                 params={
                     'database_id': database_id,


### PR DESCRIPTION
## What?
`CheckPermissionClient` の `is_permitted` が常に False を返すバグを修正
(405 Method Not Allowed が返ってきて raise される)

## Why?
バグ修正のため
