### PR TITLE
Fix the bug that `getConfig` always fails

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -36,7 +36,7 @@ def get_config(
 
     """
     try:
-        check_permission_client.check_permissions('databases:read:public', database_id)
+        check_permission_client.check_permissions('databases:read', database_id)
         resp = _get_config(escape_string(database_id, kind='id'))
         resp = filter_data(resp)
         return resp


### PR DESCRIPTION
## What?
`getConfig` が常に PermissionError になってしまうバグを修正

`databases:read` が必要なのに間違えて `databases:read:public` を指定していたのが原因

## Why?
バグ修正のため