### PR TITLE
Fix the bug that searching with `=` fails

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -3,13 +3,13 @@
 """Utilities."""
 
 import datetime
+from distutils.util import strtobool
 import json
 import os
 import re
 from typing import List
 
-from dataware_tools_api_helper import get_forward_headers
-from fastapi import Header, HTTPException
+from fastapi import Header
 from pydtk.db import V4DBHandler as DBHandler
 import requests
 
@@ -128,7 +128,7 @@ def parse_search_keyword(search_keyword: str, columns=None):
         elif '!=' in key:
             query += _parse_search_keyword(key, '!=')
         elif '=' in key:
-            query += _parse_search_keyword(key, '=')
+            query += _parse_search_keyword(key, '==')
         elif '>' in key:
             query += _parse_search_keyword(key, '>')
         elif '<' in key:
@@ -386,7 +386,7 @@ def get_check_permission_client(authorization: str = Header(None)):
         - https://fastapi.tiangolo.com/tutorial/dependencies/
 
     """
-    if os.environ.get('API_IGNORE_PERMISSION_CHECK', False):
+    if strtobool(os.environ.get('API_IGNORE_PERMISSION_CHECK', False)):
         return DummyCheckPermissionClient(authorization)
     return CheckPermissionClient(authorization)
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -128,7 +128,7 @@ def parse_search_keyword(search_keyword: str, columns=None):
         elif '!=' in key:
             query += _parse_search_keyword(key, '!=')
         elif '=' in key:
-            query += _parse_search_keyword(key, '==')
+            query += _parse_search_keyword(key, '=', replace_expression='==')
         elif '>' in key:
             query += _parse_search_keyword(key, '>')
         elif '<' in key:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -87,3 +87,15 @@ def test_get_secret_columns(init):
     )
     assert r.status_code == 200
     assert get_secret_columns('default') == ['path']
+
+
+def test_parse_search_keyword():
+    """Test `parse_search_keyword`."""
+    from api.utils import parse_search_keyword
+
+    assert parse_search_keyword('abc:def') == "'abc' == regex('def')"
+    assert parse_search_keyword('time>0') == "'time' > 0"
+    assert parse_search_keyword('time<0') == "'time' < 0"
+    assert parse_search_keyword('time>=0') == "'time' >= 0"
+    assert parse_search_keyword('time<=0') == "'time' <= 0"
+    assert parse_search_keyword('time=0') == "'time' == 0"


### PR DESCRIPTION
## What?
Resolve https://github.com/dataware-tools/dataware-tools/issues/33
`=` が `search_keyword` に入っているとエラーになるバグを修正

## Why?
バグ修正のため
