### PR TITLE
Add permission check for list-database resource

### DIFF
--- a/api/databases.py
+++ b/api/databases.py
@@ -217,7 +217,7 @@ def _list_databases(sort_key: str,
     order_by = [(sort_key, 1)]
 
     # Read all data
-    handler.read(pql=pql, limit=per_page, offset=begin, order_by=order_by)
+    handler.read(pql=pql, limit=None, offset=0, order_by=order_by)
     all_data = handler.data
 
     # Filter database-ids based on user's permissions

--- a/api/databases.py
+++ b/api/databases.py
@@ -216,22 +216,28 @@ def _list_databases(sort_key: str,
     pql = parse_search_keyword(search_keyword, search_key)
     order_by = [(sort_key, 1)]
 
-    # Read
+    # Read all data
     handler.read(pql=pql, limit=per_page, offset=begin, order_by=order_by)
+    all_data = handler.data
 
-    # TODO: Filter database-ids based on user's permissions
+    # Filter database-ids based on user's permissions
+    _, permitted_database_indices = check_permission_client.filter_permitted_databases(
+        [item['database_id'] for item in all_data],
+    )
+    permitted_database_objects = [all_data[index] for index in permitted_database_indices]
 
-    total = handler.count_total
+    # Pagination
+    paged_data = permitted_database_objects[begin:begin + per_page]
+    total = len(permitted_database_objects)
     number_of_pages = math.ceil(total / per_page)
-    data = handler.data
 
     resp = {
-        'data': data,
+        'data': paged_data,
         'page': page,
         'per_page': per_page,
         'number_of_pages': number_of_pages,
         'sort_key': sort_key,
-        'length': len(data),
+        'length': len(paged_data),
         'total': total
     }
 

--- a/api/utils.py
+++ b/api/utils.py
@@ -7,7 +7,7 @@ from distutils.util import strtobool
 import json
 import os
 import re
-from typing import List
+from typing import List, Tuple
 
 from fastapi import Header
 from pydtk.db import V4DBHandler as DBHandler
@@ -370,14 +370,15 @@ class CheckPermissionClient:
                 f'Action "{action_id}" is not allowed on database "{database_id}"'
             )
 
-    def filter_permitted_databases(self, database_ids: List[str]) -> List[str]:
+    def filter_permitted_databases(self, database_ids: List[str]) -> Tuple[List[str], List[int]]:
         """Return ids of permitted databases filtered from input database_ids.
 
         Args:
             database_ids (List[str])
 
         Returns:
-            (List[str])
+            (List[str]): List of permitted databases.
+            (List[int]): Indices of permitted databases in the input list.
 
         """
         try:
@@ -392,9 +393,9 @@ class CheckPermissionClient:
             )
             response.raise_for_status()
             response_data = json.loads(response.text)
-            return response_data['database_ids']
+            return response_data['database_ids'], response_data['selected_indices']
         except Exception:
-            return []
+            return [], []
 
 
 class DummyCheckPermissionClient(CheckPermissionClient):
@@ -404,9 +405,9 @@ class DummyCheckPermissionClient(CheckPermissionClient):
         """Allow all."""
         return True
 
-    def filter_permitted_databases(self, database_ids: List[str]) -> List[str]:
+    def filter_permitted_databases(self, database_ids: List[str]) -> Tuple[List[str], List[int]]:
         """Allow all."""
-        return database_ids
+        return database_ids, list(range(len(database_ids)))
 
 
 def get_check_permission_client(authorization: str = Header(None)):

--- a/api/utils.py
+++ b/api/utils.py
@@ -370,6 +370,32 @@ class CheckPermissionClient:
                 f'Action "{action_id}" is not allowed on database "{database_id}"'
             )
 
+    def filter_permitted_databases(self, database_ids: List[str]) -> List[str]:
+        """Return ids of permitted databases filtered from input database_ids.
+
+        Args:
+            database_ids (List[str])
+
+        Returns:
+            (List[str])
+
+        """
+        try:
+            response = requests.get(
+                f'{self.PERMISSION_MANAGER_SERVICE}/permitted-databases',
+                headers={
+                    'authorization': self.auth_header,
+                },
+                json={
+                    'database_ids': database_ids,
+                },
+            )
+            response.raise_for_status()
+            response_data = json.loads(response.text)
+            return response_data['database_ids']
+        except Exception:
+            return []
+
 
 class DummyCheckPermissionClient(CheckPermissionClient):
     """Dummy object of CheckPermissionClient (for debugging and testing)."""
@@ -377,6 +403,10 @@ class DummyCheckPermissionClient(CheckPermissionClient):
     def is_permitted(self, *args, **kwargs) -> bool:
         """Allow all."""
         return True
+
+    def filter_permitted_databases(self, database_ids: List[str]) -> List[str]:
+        """Allow all."""
+        return database_ids
 
 
 def get_check_permission_client(authorization: str = Header(None)):

--- a/test/test_databases.py
+++ b/test/test_databases.py
@@ -35,6 +35,16 @@ def add_data():
     add_database('default')
 
 
+@pytest.fixture
+def add_multiple_data():
+    _set_env()
+    add_database('default')
+    add_database('database1')
+    add_database('database2')
+    add_database('database3')
+    add_database('database4')
+
+
 def test_list_databases_200(init, add_data):
     _set_env()
     r = client.get('/databases')
@@ -42,6 +52,36 @@ def test_list_databases_200(init, add_data):
     data = json.loads(r.text)
     _assert_list_response(data)
     assert len(data['data']) > 0
+
+
+def test_list_databases_with_pagination_200(init, add_multiple_data):
+    _set_env()
+    # Get first page
+    r = client.get('/databases', params={
+        'per_page': 3,
+        'page': 1,
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) == 3
+
+    # Get second page
+    r = client.get('/databases', params={
+        'per_page': 3,
+        'page': 2,
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) == 2
+
+    # Get third page
+    r = client.get('/databases', params={
+        'per_page': 3,
+        'page': 3,
+    })
+    assert r.status_code == 200
+    data = json.loads(r.text)
+    assert len(data['data']) == 0
 
 
 def test_fuzzy_search_databases_200(init, add_data):


### PR DESCRIPTION
## What?

データベース一覧のリソースに api-permission-manager を通じた閲覧可能データベースのフィルタリング機能追加

## Why?

権限により閲覧できるデータベースを制限したい

## See also [Optional]

- Issue: https://github.com/dataware-tools/dataware-tools/issues/13
