### PR TITLE
Fix the bug that no records were returned when record_id was numeric value

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -112,7 +112,7 @@ def parse_search_keyword(search_keyword: str, columns=None):
     if columns is None:
         columns = ['tags']
 
-    if search_keyword is None:
+    if search_keyword in [None, ""]:
         return None
 
     query = ''


### PR DESCRIPTION
## What?
Fix dataware-tools/dataware-tools#50
`record_id` が数字のみの場合に `listRecords` が何も返さないバグを修正
(根本解決ではない)

## Why?
バグ修正のため

## Note
MongoDBの `regex` が数字に対しては適応されないのが原因  
検索キーワードが空欄の場合に `regex(".*")` によるフィルタリングを行わない様にして対処した