### PR TITLE
Fix the bug that the permission-client fails to init with the default env-var

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -417,7 +417,7 @@ def get_check_permission_client(authorization: str = Header(None)):
         - https://fastapi.tiangolo.com/tutorial/dependencies/
 
     """
-    if strtobool(os.environ.get('API_IGNORE_PERMISSION_CHECK', False)):
+    if strtobool(os.environ.get('API_IGNORE_PERMISSION_CHECK', 'false')):
         return DummyCheckPermissionClient(authorization)
     return CheckPermissionClient(authorization)
 


### PR DESCRIPTION
## What?
Fix the bug that the permission-client fails to init with the default env-var

## Why?
Bug fix
