### PR TITLE
Fix bug that PATCH /databases/{database_id} requires database_id

### DIFF
--- a/api/databases.py
+++ b/api/databases.py
@@ -317,8 +317,8 @@ def _update_database(database_id, info):
     database_info = _get_database(database_id)
 
     # Check info
-    assert 'database_id' in info.keys()
-    assert database_id == info['database_id'], "'database_id' cannot be changed"
+    if 'database_id' in info.keys():
+        assert database_id == info['database_id'], "'database_id' cannot be changed"
 
     # Patch info
     database_info.update(info)

--- a/test/test_databases.py
+++ b/test/test_databases.py
@@ -173,7 +173,6 @@ def test_update_database_200(init, add_data):
     r = client.patch(
         '/databases/default',
         json={
-            'database_id': 'default',
             'description': 'new-description',
             'tag': 'new-tag'
         }


### PR DESCRIPTION
## What?
- Fix bug that PATCH /databases/{database_id} requires database_id

## Why?
- API 仕様書と齟齬があったから

## See also
- Resolves https://github.com/dataware-tools/dataware-tools/issues/52