### PR TITLE
Support case-insensitive keyword search

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -136,7 +136,7 @@ def parse_search_keyword(search_keyword: str, columns=None):
         else:
             filters = []
             for column in columns:
-                filters.append(_parse_search_keyword('{0}:.*{1}.*'.format(column, key), ':',
+                filters.append(_parse_search_keyword('{0}:.*(?i){1}.*'.format(column, key), ':',
                                                      replace_expression='regex'))
             query += '(' + ' or '.join(filters) + ')'
 

--- a/test/test_records.py
+++ b/test/test_records.py
@@ -171,7 +171,7 @@ def test_fuzzy_search_records_200(init, add_data):
     r = client.get(
         '/databases/default/records',
         params={
-            'search': 'Desc',
+            'search': 'dEsC',
             'search_key': ['record_id', 'description']
         }
     )


### PR DESCRIPTION
## What?
- Support case-insensitive  keyword search

## Why?
- Data-browser should request API case-insensitive keyword search 

## See also
- Resolves https://github.com/dataware-tools/dataware-tools/issues/39
