### PR TITLE
Add config for tools that does not support "exports" field

### DIFF
--- a/build_client/typescript/package.json
+++ b/build_client/typescript/package.json
@@ -17,6 +17,8 @@
       "./dist/browser/index.mjs"
     ]
   },
+  "main": "./dist/node/index.cjs",
+  "browser": "./dist/browser/index.mjs",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## What?
Add config for tools that does not support "exports" field

## Why?
Some major tools does not support "exports" field

## See also
[When a package has an "exports" field, this will take precedence over the "main" field in Node](https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#main)
[Jest does not fully support "exports" field yet](https://github.com/facebook/jest/issues/9771)
["browser" field is useful for replace entry point](https://github.com/defunctzombie/package-browser-field-spec#spec)
[Webpack recommend to use "browser" field](https://webpack.js.org/migrate/5/#:~:text=use%20the%20browser%20field)