### PR TITLE
Fix the bug that field 'path' is updated unexpectedly in update_record function

### DIFF
--- a/api/records.py
+++ b/api/records.py
@@ -424,6 +424,8 @@ def _update_record(database_id: str, record_id: str, info):
     # Update data one-by-one
     for data in handler.data:
         data.update(info)
+        if 'path' in data.keys() and data['path'] in ['', '/']:
+            del data['path']
         handler.add_data(data, strategy='overwrite')
 
     # Save

--- a/test/test_records.py
+++ b/test/test_records.py
@@ -44,6 +44,7 @@ def add_record(database_id='default', record_id='pytest'):
             'list': ['a', 'b', 'c'],
             'tags': ['tag1', 'tag2'],
             'secret_column': 'data',
+            'path': ''
         }
     )
 
@@ -278,6 +279,11 @@ def test_get_record_404(init, add_data):
 
 def test_update_record_200(init, add_data):
     _set_env()
+    r = client.get(
+        '/databases/default/records/pytest',
+    )
+    assert r.status_code == 200
+    original_data = json.loads(r.text)
     r = client.patch(
         '/databases/default/records/pytest',
         json={
@@ -299,6 +305,7 @@ def test_update_record_200(init, add_data):
     assert 'record_id' in data.keys()
     assert data['description'] == 'new-description'
     assert data['tag'] == 'new-tag'
+    assert data['path'] == original_data['path']
 
 
 def test_update_record_with_none(init, add_data):


### PR DESCRIPTION
## What?
Fix the bug that `path` field is changed to `/.` unexpectedly when `update_record` is called

## Why?
Bug fix
