### PR TITLE
fix the default value of `per_page` for list_files

### DIFF
--- a/api/files.py
+++ b/api/files.py
@@ -32,7 +32,7 @@ def list_files(
     *,
     record_id: str = None,
     sort_key: str = 'path',
-    per_page: int = 50,
+    per_page: int = 1000,
     page: int = 1,
     search: str = None,
     search_key: Optional[List[str]] = Query(None),


### PR DESCRIPTION
## What?
Increase the default value of `per_page` for `list_files`

## Why?
To fix the problem that files are listed incompletely in data-browser